### PR TITLE
fix jenkins exerstack tests on redhat distros

### DIFF
--- a/all.sh
+++ b/all.sh
@@ -140,8 +140,7 @@ chef-client -ldebug
 EOF
 
 x_with_server "fixerating" api <<EOF
-install_package swift
-ip addr add 192.168.100.254/24 dev br99
+fix_for_tests
 EOF
 background_task "fc_do"
 collect_tasks

--- a/files/fakeconfig.sh
+++ b/files/fakeconfig.sh
@@ -309,3 +309,14 @@ function flush_iptables() {
     iptables -P FORWARD ACCEPT
     iptables -P OUTPUT ACCEPT
 }
+
+function fix_for_tests() {
+
+    if [ $PLATFORM = "debian" ] || [ $PLATFORM = "ubuntu" ]; then
+        install_package "swift"
+    elif [ $PLATFORM = "redhat" ]; then
+        install_package "openstack-swift"
+    fi
+
+    ip addr add 192.168.100.254/24 dev br99
+}


### PR DESCRIPTION
- redhat needs 'openstack-swift' not 'swift'
