### PR TITLE
Revert "use the rackspace mirrors for centos"

### DIFF
--- a/files/fakeconfig.sh
+++ b/files/fakeconfig.sh
@@ -164,19 +164,16 @@ function set_package_provider() {
     elif [ $PLATFORM = "centos" ]; then
         # whack the cron jobs so they don't start on system boot
         chmod 000 /etc/cron.{d,daily,monthly,hourly,monthly}/*
-
-        # let's try this out again...
-        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/CentOS-Base.repo
-        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-Base.repo
-        sed -i 's/mirror.centos.org\/centos/mirror.rackspace.com\/CentOS/g' /etc/yum.repos.d/CentOS-Base.repo
-        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/epel.repo
-        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/epel.repo
-        sed -i 's/download.fedoraproject.org\/pub/mirror.rackspace.com/g' /etc/yum.repos.d/epel.repo
-        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/epel-testing.repo
-        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/epel-testing.repo
-        sed -i 's/download.fedoraproject.org\/pub/mirror.rackspace.com/g' /etc/yum.repos.d/epel-testing.repo
-
-#        echo "include_only=.edu,.gov" >> /etc/yum/pluginconf.d/fastestmirror.conf
+#        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/CentOS-Base.repo
+#        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/CentOS-Base.repo
+#        sed -i 's/mirror.centos.org\/centos/mirror.rackspace.com\/CentOS/g' /etc/yum.repos.d/CentOS-Base.repo
+#        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/epel.repo
+#        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/epel.repo
+#        sed -i 's/download.fedoraproject.org\/pub/mirror.rackspace.com/g' /etc/yum.repos.d/epel.repo
+#        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/epel-testing.repo
+#        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/epel-testing.repo
+#        sed -i 's/download.fedoraproject.org\/pub/mirror.rackspace.com/g' /etc/yum.repos.d/epel-testing.repo
+        echo "include_only=.edu,.gov" >> /etc/yum/pluginconf.d/fastestmirror.conf
         echo "proxy=${JENKINS_PROXY}" >> /etc/yum.conf
         yum clean all
     fi


### PR DESCRIPTION
This reverts commit efc9f28f787a160857404427a497e97e6aed1f9c.

sadly, we started to see errors with the rackspace mirrors almost
immediately.  The same errors we saw that caused us to not use the Rackspace mirrors (checksum errors with manifest files).

This latest issue seems to be caused by a mirror update on 28th July, and subsequent centos gates are failing with:

<pre>"http://mirror.rackspace.com/epel/6/x86_64/repodata/pkgtags.sqlite.gz: [Errno -1] Metadata file does not match checksum
Trying other mirror.
Error: failure: repodata/pkgtags.sqlite.gz from epel: [Errno 256] No more mirrors to try."</pre>
