### PR TITLE
add mini-ha-neutron gate

### DIFF
--- a/chef-jenkins.sh
+++ b/chef-jenkins.sh
@@ -78,9 +78,10 @@ function setup_quantum_network() {
         exit 1
     fi
     quantum net-create "${JOBID}-mgmt"
-    quantum subnet-create --name "${JOBID}-mgmt" --no-gateway --dns-nameserver 10.127.52.28 "${JOBID}-mgmt" 192.168.0.0/24
+#    quantum subnet-create --name "${JOBID}-mgmt" --no-gateway --dns-nameserver 10.127.52.28 "${JOBID}-mgmt" 192.168.0.0/24
+    quantum subnet-create --name "${JOBID}-mgmt" --no-gateway --dns-nameserver 8.8.8.8 "${JOBID}-mgmt" 192.168.0.0/24
     quantum net-create "${JOBID}-vmnet"
-    quantum subnet-create --name "${JOBID}-vmnet" --no-gateway "${JOBID}-vmnet" 192.168.50.0/24
+    quantum subnet-create --name "${JOBID}-vmnet" --no-gateway --dns-nameserver 8.8.8.8 "${JOBID}-vmnet" 192.168.50.0/24
 }
 
 function destroy_quantum_network() {
@@ -852,7 +853,7 @@ function role_add() {
 
     knife node run_list add ${chef_node_name} "${role}" -c ${knife} > /dev/null
 }
-alias run_list_add role_add
+
 function x_with_server() {
     OPERANT_SERVER=$2
     fc_reset_tasks

--- a/files/fakeconfig.sh
+++ b/files/fakeconfig.sh
@@ -134,6 +134,20 @@ function cleanup_metadata_routes() {
     done
 }
 
+function move_ip_to_ovs_bridge() {
+    physdev=$1
+    bridgedev="br-${physdev}"
+    IP=$(ip a show dev $physdev | grep "inet " | awk '{print $2}')
+    ifdown $physdev >/dev/null 2>&1
+    ip l s $physdev up
+    ovs-vsctl add-br $bridgedev
+    ovs-vsctl add-port $bridgedev $physdev
+    ip l s $bridgedev up
+    ip a a ${IP} dev $bridgedev
+}
+
+
+
 function add_repo() {
     # $1 repo description
 

--- a/files/fakeconfig.sh
+++ b/files/fakeconfig.sh
@@ -187,8 +187,8 @@ function set_package_provider() {
 #        sed -i '/^mirrorlist.*/d' /etc/yum.repos.d/epel-testing.repo
 #        sed -i 's/^#baseurl/baseurl/g' /etc/yum.repos.d/epel-testing.repo
 #        sed -i 's/download.fedoraproject.org\/pub/mirror.rackspace.com/g' /etc/yum.repos.d/epel-testing.repo
-        echo "include_only=.edu,.gov" >> /etc/yum/pluginconf.d/fastestmirror.conf
-        echo "exclude=ftp.ussq.iu.edu, .arsc.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf
+#        echo "include_only=.edu,.gov" >> /etc/yum/pluginconf.d/fastestmirror.conf
+        echo "exclude=.iu.edu, .arsc.edu" >> /etc/yum/pluginconf.d/fastestmirror.conf
         echo "proxy=${JENKINS_PROXY}" >> /etc/yum.conf
 #        yum clean all
         yum clean all && yum clean metadata && yum clean dbcache && yum makecache

--- a/files/minicluster-neutron.json
+++ b/files/minicluster-neutron.json
@@ -1,0 +1,104 @@
+{
+    "cookbook_versions": {
+    },
+    "json_class": "Chef::Environment",
+    "override_attributes": {
+       "quantum": {
+          "ovs": {
+            "network_type": "gre",
+            "provider_networks": [
+              {
+              "label": "ph-eth2",
+              "bridge": "br-eth2",
+              "vlans": "1:1000"
+              }
+            ]
+          }
+        },
+        "monitoring": {
+            "metric_provider": "collectd",
+            "procmon_provider": "monit"
+        },
+        "horizon": {
+          "theme": "Rackspace"
+        },
+        "vips": {
+          "rabbitmq-queue": "192.168.0.240",
+          "horizon-dash": "192.168.0.241",
+          "horizon-dash_ssl": "192.168.0.241",
+          "keystone-service-api": "192.168.0.241",
+          "keystone-admin-api": "192.168.0.241",
+          "keystone-internal-api": "192.168.0.241",
+          "nova-xvpvnc-proxy": "192.168.0.241",
+          "nova-api": "192.168.0.241",
+          "nova-ec2-public": "192.168.0.241",
+          "nova-novnc-proxy": "192.168.0.241",
+          "cinder-api": "192.168.0.241",
+          "quantum-api": "192.168.0.241",
+          "glance-api": "192.168.0.241",
+          "glance-registry": "192.168.0.241",
+          "swift-proxy": "192.168.0.241",
+          "mysql-db": "192.168.0.242",
+          "config": {
+            "192.168.0.240": {
+              "vrid": 11,
+              "network": "public"
+            },
+            "192.168.0.241": {
+              "vrid": 12,
+              "network": "public"
+            },
+            "192.168.0.242": {
+              "vrid": 10,
+              "network": "public"
+            }
+          }
+        },
+        "osops": {
+            "apply_patches": true
+        },
+        "cinder": {
+            "config": {
+                "log_verbosity": "DEBUG"
+            }
+        },
+        "keystone": {
+            "config": {
+                "log_verbosity": "DEBUG"
+            }
+        },
+        "nova": {
+            "debug": true,
+            "network": {
+                "multi_host": true,
+                "provider": "quantum"
+            },
+            "libvirt": {
+                "virt_type": "qemu"
+            }
+        },
+        "glance": {
+            "image_upload": true,
+            "api": {
+                "default_store": "file"
+            },
+            "images": [
+                "cirros"
+            ]
+        },
+        "mysql": {
+            "allow_remote_root": true,
+            "root_network_acl": "%"
+        },
+        "osops_networks": {
+            "management": "192.168.0.0/24",
+            "nova": "192.168.0.0/24",
+            "swift": "192.168.0.0/24",
+            "swift-lb": "192.168.0.0/24",
+            "public": "192.168.0.0/24"
+        }
+    },
+    "name": "minicluster-neutron",
+    "chef_type": "environment",
+    "description": ""
+}

--- a/mini-ha-neutron.sh
+++ b/mini-ha-neutron.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+
+START_TIME=$(date +%s)
+PACKAGE_COMPONENT=${PACKAGE_COMPONENT:-grizzly}
+
+GRAB_LOGFILES_ON_FAILURE=0
+JOB_ARCHIVE_FILES="/var/log,/etc,/var/lib/nova/instances/*/*.xml,/var/lib/nova/instances/*/*.log}"
+
+source $(dirname $0)/chef-jenkins.sh
+
+print_banner "Initializing Job"
+init
+
+CHEF_ENV="minicluster-neutron"
+print_banner "Build Parameters
+~~~~~~~~~~~~~~~~
+environment = ${CHEF_ENV}
+INSTANCE_IMAGE=${INSTANCE_IMAGE}
+AVAILABILITY_ZONE=${AZ}
+TMPDIR = ${TMPDIR}
+GIT_PATCH_URL = ${GIT_PATCH_URL}
+GIT_MASTER_URL = ${GIT_MASTER_URL}
+We are building for ${PACKAGE_COMPONENT}"
+
+rm -rf logs
+mkdir -p logs/run
+exec 9>logs/run/out.log
+BASH_XTRACEFD=9
+set -x
+
+declare -a cluster
+cluster=(api api2 compute1 compute2)
+#cluster=(api compute1)
+
+start_timer
+setup_quantum_network
+stop_timer
+
+start_timer
+print_banner "creating chef server"
+boot_and_wait chef-server
+wait_for_ssh chef-server
+stop_timer
+
+start_timer
+x_with_server "Fixing up the chef-server and booting the cluster" "chef-server" <<EOF
+set_package_provider
+update_package_provider
+flush_iptables
+run_twice install_package git-core
+fixup_hosts_file_for_quantum
+chef11_fixup
+EOF
+background_task "fc_do"
+
+boot_cluster ${cluster[@]}
+stop_timer
+
+start_timer
+print_banner "Waiting for IP connectivity to the instances"
+wait_for_cluster_ssh ${cluster[@]}
+print_banner "Waiting for SSH to become available"
+wait_for_cluster_ssh_key ${cluster[@]}
+stop_timer
+
+start_timer
+x_with_cluster "Cluster booted.  Setting up the package providers and quantum networks" ${cluster[@]} <<EOF
+plumb_quantum_networks eth1
+plumb_quantum_networks eth2
+# set_quantum_network_link_up eth2
+cleanup_metadata_routes eth0 eth1
+fixup_hosts_file_for_quantum
+wait_for_rhn
+set_package_provider
+update_package_provider
+run_twice install_package bridge-utils
+run_twice install_package openvswitch-switch
+move_ip_to_ovs_bridge eth2
+EOF
+stop_timer
+
+start_timer
+print_banner "Setting up the chef environment"
+# at this point, chef server is done, cluster is up.
+# let's set up the environment.
+create_chef_environment chef-server ${CHEF_ENV}
+# Set the package_component environment variable (not really needed in grizzly but no matter)
+knife_set_package_component chef-server ${CHEF_ENV} ${PACKAGE_COMPONENT}
+stop_timer
+
+# if we have been provided a chef cookbook tarball let's use it otherwise
+# upload the cookbooks the normal way.  If we have the tarball the upload
+# is initiated from the build server, otherwise all the work is done on the
+# chef-server VM
+if [[ ! -f ${COOKBOOKS_TARBALL} ]]; then
+  start_timer
+  x_with_server "uploading the cookbooks" "chef-server" <<EOF
+  checkout_cookbooks
+  run_twice upload_cookbooks
+  run_twice upload_roles
+EOF
+  background_task "fc_do"
+  stop_timer
+else
+  unpack_local_chef_tarball ${COOKBOOKS_TARBALL}
+  upload_local_chef_cookbooks chef-server
+  upload_local_chef_roles chef-server
+fi
+
+start_timer
+x_with_cluster "Installing chef-client and running for the first time" ${cluster[@]} <<EOF
+flush_iptables
+install_chef_client
+chef11_fetch_validation_pem $(ip_for_host chef-server)
+copy_file client-template.rb /etc/chef/client-template.rb
+template_client $(ip_for_host chef-server)
+chef-client
+EOF
+stop_timer
+
+# fix up api node with a cinder-volumes vg
+start_timer
+x_with_cluster "setting up cinder-volumes vg on api node for cinder" api <<EOF
+install_package lvm2
+umount /mnt
+pvcreate /dev/vdb
+vgcreate cinder-volumes /dev/vdb
+EOF
+stop_timer
+
+start_timer
+role_add chef-server api "role[ha-controller1],role[cinder-volume],role[single-network-node]"
+x_with_cluster "Installing the first controller" api <<EOF
+chef-client
+EOF
+stop_timer
+
+start_timer
+echo "turning off image upload"
+set_environment_attribute chef-server ${CHEF_ENV} "override_attributes/glance/image_upload" "false"
+stop_timer
+
+start_timer
+role_add chef-server api2 "role[ha-controller2]"
+x_with_cluster "Installing the second controller" api2 <<EOF
+chef-client
+EOF
+stop_timer
+
+start_timer
+role_add chef-server api "recipe[kong],recipe[exerstack]"
+x_with_cluster "Finalizing the installation on the first controller" api <<EOF
+chef-client
+EOF
+stop_timer
+
+start_timer
+role_add chef-server compute1 "role[single-compute]"
+role_add chef-server compute2 "role[single-compute]"
+x_with_cluster "Running chef on the compute nodes" compute1 compute2 <<EOF
+chef-client
+EOF
+stop_timer
+
+start_timer
+# this is here so we don't get random image failures with the images
+# not syncing from one node to another
+x_with_server "stopping glance services on second node" api2 <<EOF
+  monit stop glance-api
+  monit stop glance-registry
+EOF
+background_task "fc_do"
+collect_tasks
+stop_timer
+
+retval=0
+
+# setup test list
+declare -a testlist=(cinder nova-neutron neutron glance keystone)
+
+start_timer
+# run tests
+if ( ! run_tests api ${PACKAGE_COMPONENT} ${testlist[@]} ); then
+    echo "Tests failed."
+    retval=1
+fi
+stop_timer
+
+if [ $retval -eq 0 ]; then
+    if [ -n "${GIT_COMMENT_URL}" ] && [ "${GIT_COMMENT_URL}" != "noop" ] ; then
+        github_post_comment ${GIT_COMMENT_URL} "Gate:  Nova AIO (${INSTANCE_IMAGE}): SUCCESS\n * ${BUILD_URL}consoleFull"
+    else
+        echo "skipping building comment"
+    fi
+fi
+
+END_TIME=$(date +%s)
+print_banner "Total time taken was approx $(( (END_TIME-START_TIME)/60 )) minutes"
+exit $retval


### PR DESCRIPTION
NOTE: currently neutron/centos is broken in the cookbooks so this should only be run for ubuntu.

This pull adds the necessary files to be able to run the old mini-ha gate using neutron as the network provider.  Also runs the neutron exerstack/kong tests as part of the gate.
