### PR TITLE
Temporarily disable Cinder secure delete for snaps

### DIFF
--- a/files/minicluster-neutron.json
+++ b/files/minicluster-neutron.json
@@ -62,7 +62,8 @@
                 "lvm": {
                     "conf": {
                         "device_filter": "[ 'a|^/dev/vd.*$|', 'r/.*/' ]"
-                    }
+                    },
+                    "volume_clear": "none"
                 }
             },
             "config": {


### PR DESCRIPTION
Workaround for LVM on CentOS 6.4.
See:
    https://bugzilla.redhat.com/show_bug.cgi?id=975052
    https://bugs.launchpad.net/cinder/+bug/1191812
    https://review.openstack.org/#/c/45114
    https://review.openstack.org/#/c/45117
